### PR TITLE
Move nightly-builds from master to feature/pronouns

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ name: Build
 on:
   push:
     branches:
-      - master
       - feature/pronouns
   pull_request:
 
@@ -239,7 +238,7 @@ jobs:
   create-release:
     needs: build
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/feature/pronouns')
 
     steps:
       - name: Create release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - feature/pronouns
   pull_request:
 
 jobs:


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description

I have gone ahead and made the necessary changes for Github Actions to automatically generate nightly builds of feature/pronouns for windows/mac/linux, but more specifically mac/linux as they were not previously supported.

The intended changes can be tested here -> [https://github.com/Felanbird-testing/chatterino2/releases/tag/nightly-build](https://github.com/Felanbird-testing/chatterino2/releases/tag/nightly-build)

I noticed that you now support chatterino7 builds of Chatterino, but I'm unaware of what would need to be changed, or duplicated, to also support them in this way, currently this PR only supports what is on the pronouns/feature branch.

